### PR TITLE
Put runner autoscaler in correct namespace

### DIFF
--- a/deployments/ubuntu-focal.yml
+++ b/deployments/ubuntu-focal.yml
@@ -37,6 +37,7 @@ apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler
 metadata:
   name: ubuntu-focal-autoscaling
+  namespace: runners
 spec:
   scaleTargetRef:
     name: ubuntu-focal


### PR DESCRIPTION
The `HorizontalRunnerAutoscaler` was in the default namespace.  This puts it in the correct namespace with the runners.