### PR TITLE
Clean up test workflows

### DIFF
--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -12,7 +12,6 @@ on:
     - 'images/docker/*'
     - 'images/patched/*'
     - 'images/software/*'
-    - 'images/supervisor/*'
 
 jobs:
   build:

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -9,7 +9,7 @@ on:
     - 'images/podman.Dockerfile'
     - '.github/workflows/**-podman.yml'
     - 'images/**.sh'
-    - 'images/docker/*'
+    - 'images/podman/*'
     - 'images/software/*'
 
 jobs:

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -10,7 +10,6 @@ on:
     - '.github/workflows/**-podman.yml'
     - 'images/**.sh'
     - 'images/docker/*'
-    - 'images/patched/*'
     - 'images/software/*'
 
 jobs:

--- a/.github/workflows/test-ubuntu-focal.yml
+++ b/.github/workflows/test-ubuntu-focal.yml
@@ -10,7 +10,6 @@ on:
     - '.github/workflows/**-focal.yml'
     - 'images/**.sh'
     - 'images/docker/*'
-    - 'images/patched/*'
     - 'images/software/*'
     - 'images/supervisor/*'
 


### PR DESCRIPTION
- Podman images don't use `supervisord` so having it run on these changes is wasteful.
- Podman images don't use `docker` configs and instead use `podman` configs, so it _should_ run on these changes.
- No images use `patched` files for the runner agent.  While fixed in #12, this was still here. 🤦🏻‍♀️  