### PR TITLE
disable automatic runner updates in deployments

### DIFF
--- a/deployments/podman.yml
+++ b/deployments/podman.yml
@@ -8,7 +8,9 @@ spec:
   template:
     spec:
       repository: some-natalie/kubernoodles
-      env: []
+      env:
+        - name: DISABLE_RUNNER_UPDATE  # Disables automatic runner updates
+          value: "true"
       ephemeral: true
       image: ghcr.io/some-natalie/kubernoodles/podman:latest # change this to the version you really want!
       imagePullPolicy: Always
@@ -31,6 +33,7 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+        runAsNonRoot: true
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler

--- a/deployments/test-podman.yml
+++ b/deployments/test-podman.yml
@@ -8,7 +8,9 @@ spec:
   template:
     spec:
       repository: some-natalie/kubernoodles
-      env: []
+      env:
+        - name: DISABLE_RUNNER_UPDATE  # Disables automatic runner updates
+          value: "true"
       ephemeral: true
       image: ghcr.io/some-natalie/kubernoodles/podman:latest
       imagePullPolicy: Always
@@ -29,3 +31,4 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+        runAsNonRoot: true

--- a/deployments/test-ubuntu-focal.yml
+++ b/deployments/test-ubuntu-focal.yml
@@ -8,7 +8,9 @@ spec:
   template:
     spec:
       repository: some-natalie/kubernoodles
-      env: []
+      env:
+        - name: DISABLE_RUNNER_UPDATE  # Disables automatic runner updates
+          value: "true"
       ephemeral: true
       image: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:latest
       imagePullPolicy: Always
@@ -29,3 +31,4 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+        runAsNonRoot: true

--- a/deployments/ubuntu-focal.yml
+++ b/deployments/ubuntu-focal.yml
@@ -8,7 +8,9 @@ spec:
   template:
     spec:
       repository: some-natalie/kubernoodles
-      env: []
+      env:
+        - name: DISABLE_RUNNER_UPDATE  # Disables automatic runner updates
+          value: "true"
       ephemeral: true
       image: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:latest # change this to the version you really want!
       imagePullPolicy: Always
@@ -32,6 +34,7 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+        runAsNonRoot: true
 ---
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler


### PR DESCRIPTION
The runner agent automatically updates itself by default, which means there's a ton of bandwidth usage on ephemeral pods if it's not always up to date.  It also delays the start of each runner.  Disable this in favor of updating it via the pod images.

Closes #45 