### PR TITLE
Refactor image tests

### DIFF
--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -87,9 +87,6 @@ jobs:
       - name: Sudo fails
         uses: ./tests/sudo-fails
 
-      - name: Container Action test
-        uses: ./tests/container
-
   remove-deploy:
     name: Delete test image deployment
     runs-on: [self-hosted, podman]

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Sudo fails
         uses: ./tests/sudo-fails
 
+      - name: Container Action test
+        uses: ./tests/container
+
   remove-deploy:
     name: Delete test image deployment
     runs-on: [self-hosted, podman]

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -10,7 +10,6 @@ on:
       - "images/**.sh"
       - "images/podman/*"
       - "images/software/*"
-      - "tests/container/*"
       - "tests/podman/*"
       - "tests/sudo-fails/*"
       - ".github/workflows/test-podman.yml"

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -72,18 +72,17 @@ jobs:
     needs: [deploy]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Print debug info
+        uses: ./tests/debug
+
       - name: Podman test
-        run: |
-          podman run hello-world
-          podman network inspect podman
-          podman info
+        uses: ./tests/podman
 
-      - name: Podman compose test
-        run: |
-          podman compose --version
-
-      - name: Print environmental variables
-        run: printenv
+      - name: Sudo fails
+        uses: ./tests/sudo-fails
 
   remove-deploy:
     name: Delete test image deployment

--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -10,6 +10,10 @@ on:
       - "images/**.sh"
       - "images/podman/*"
       - "images/software/*"
+      - "tests/container/*"
+      - "tests/podman/*"
+      - "tests/sudo-fails/*"
+      - ".github/workflows/test-podman.yml"
 
 jobs:
   build:

--- a/.github/workflows/test-rootless-ubuntu-focal.yml
+++ b/.github/workflows/test-rootless-ubuntu-focal.yml
@@ -11,6 +11,10 @@ on:
       - "images/docker/*"
       - "images/software/*"
       - "images/supervisor/*"
+      - "tests/container/*"
+      - "tests/docker/*"
+      - "tests/sudo-fails/*"
+      - ".github/workflows/test-rootless-ubuntu-focal.yml"
 
 jobs:
   build:

--- a/.github/workflows/test-rootless-ubuntu-focal.yml
+++ b/.github/workflows/test-rootless-ubuntu-focal.yml
@@ -66,19 +66,20 @@ jobs:
     needs: [deploy]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Print debug info
+        uses: ./tests/debug
+
       - name: Docker test
-        run: |
-          docker run hello-world
-          docker network inspect bridge
-          docker network inspect bridge | grep -q '"com.docker.network.driver.mtu": "1400"'
-          docker info
+        uses: ./tests/docker
 
-      - name: Docker compose test
-        run: |
-          docker-compose --version
+      - name: Sudo fails
+        uses: ./tests/sudo-fails
 
-      - name: Print environmental variables
-        run: printenv
+      - name: Container Action test
+        uses: ./tests/container
 
   remove-deploy:
     name: Delete test image deployment

--- a/.github/workflows/test-ubuntu-focal.yml
+++ b/.github/workflows/test-ubuntu-focal.yml
@@ -73,21 +73,20 @@ jobs:
     needs: [deploy]
 
     steps:
-      - name: Sudo test
-        run: sudo echo "sudo is working"
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Print debug info
+        uses: ./tests/debug
 
       - name: Docker test
-        run: |
-          docker run hello-world
-          docker network inspect bridge
-          docker info
+        uses: ./tests/docker
 
-      - name: Docker compose test
-        run: |
-          docker-compose --version
+      - name: Sudo works
+        uses: ./tests/sudo-works
 
-      - name: Print environmental variables
-        run: printenv
+      - name: Container Action test
+        uses: ./tests/container
 
   remove-deploy:
     name: Delete test image deployment

--- a/.github/workflows/test-ubuntu-focal.yml
+++ b/.github/workflows/test-ubuntu-focal.yml
@@ -11,6 +11,10 @@ on:
       - "images/docker/*"
       - "images/software/*"
       - "images/supervisor/*"
+      - "tests/container/*"
+      - "tests/docker/*"
+      - "tests/sudo-works/*"
+      - ".github/workflows/test-ubuntu-focal.yml"
 
 jobs:
   build:

--- a/.github/workflows/test-ubuntu-jammy.yml
+++ b/.github/workflows/test-ubuntu-jammy.yml
@@ -73,21 +73,20 @@ jobs:
     needs: [deploy]
 
     steps:
-      - name: Sudo test
-        run: sudo echo "sudo is working"
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Print debug info
+        uses: ./tests/debug
 
       - name: Docker test
-        run: |
-          docker run hello-world
-          docker network inspect bridge
-          docker info
+        uses: ./tests/docker
 
-      - name: Docker compose test
-        run: |
-          docker-compose --version
+      - name: Sudo works
+        uses: ./tests/sudo-works
 
-      - name: Print environmental variables
-        run: printenv
+      - name: Container Action test
+        uses: ./tests/container
 
   remove-deploy:
     name: Delete test image deployment

--- a/.github/workflows/test-ubuntu-jammy.yml
+++ b/.github/workflows/test-ubuntu-jammy.yml
@@ -11,6 +11,10 @@ on:
       - "images/docker/*"
       - "images/software/*"
       - "images/supervisor/*"
+      - "tests/container/*"
+      - "tests/docker/*"
+      - "tests/sudo-works/*"
+      - ".github/workflows/test-ubuntu-jammy.yml"
 
 jobs:
   build:

--- a/images/podman.Dockerfile
+++ b/images/podman.Dockerfile
@@ -34,9 +34,7 @@ RUN dnf install -y \
     skopeo \
     slirp4netns \
     && dnf clean all \
-    && touch /etc/containers/nodocker \
-    && echo 'podman:10000:65536' >> /etc/subuid \
-    && echo 'podman:10000:65536' >> /etc/subgid
+    && touch /etc/containers/nodocker
 
 # Install kubectl
 COPY images/software/kubectl.sh /kubectl.sh

--- a/images/podman.Dockerfile
+++ b/images/podman.Dockerfile
@@ -33,7 +33,10 @@ RUN dnf install -y \
     podman-compose \
     skopeo \
     slirp4netns \
-    && dnf clean all
+    && dnf clean all \
+    && touch /etc/containers/nodocker \
+    && echo 'podman:10000:65536' >> /etc/subuid \
+    && echo 'podman:10000:65536' >> /etc/subgid
 
 # Install kubectl
 COPY images/software/kubectl.sh /kubectl.sh
@@ -58,7 +61,7 @@ COPY images/entrypoint.sh /usr/local/bin/
 COPY --chown=podman:podman images/podman/87-podman.conflist /home/podman/.config/cni/net.d/87-podman.conflist
 COPY images/podman/11-tcp-mtu-probing.conf /etc/sysctl.d/11-tcp-mtu-probing.conf
 
-RUN chmod +x /usr/local/bin/entrypoint.sh 
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 VOLUME $HOME/.local/share/containers/storage
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Tests for images
+
+This folder contains tests for the images built by the project, broken up as logically as I can.  The idea is to have a framework to expand test coverage of the images while keeping the build/test workflows in `~./github/workflows/` as succinct as possible.  These are more towards E2E testing, as it's going to run only after the image has successfully:
+
+1. Builds and is pushed to the registry
+2. Deployed to the cluster
+3. Attaches to GitHub as a self-hosted runner
+
+The tests are also pretty chill about versions and such, checking for specific things only as needed and relying on failures.  An example would be "docker run hello-world" which will fail if Docker's daemon isn't running, but there's no additional feedback or checks requested.  If needed, you can expand these tests to, say, pipe output into grep to search for a string, etc.
+
+:information_source:  The design of the project is to have self-hosted GitHub Actions runners build, test, manage, and deploy themselves as much as possible - even if other testing frameworks may provide earlier feedback or be easier to write/maintain for testing.  Minimizing dependencies is a good thing in and of itself. :heart:
+
+## Tests
+
+Here's the current tests, what they do, and why.
+
+- `container` (container Action) - builds a container Action from Dockerfile to run
+- `debug` (composite Action) - dumps debug information to the console
+  - environment variables
+  - user information
+- `docker` (composite Action) - tests Docker functionality
+  - verifies Docker daemon is up
+  - runs `hello-world` to verify Docker works
+  - prints some debug info about Docker and the network it uses to the console
+- `podman` (composite Action) - tests Podman functionality
+  - verifies Podman, Buildah, and Skopeo are installed
+  - runs `hello-world` to verify Podman works
+  - verifies "podman compose" works
+  - verifies the alias to "docker" works
+  - prints some debug info about versions and container networks to the console

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,3 +28,5 @@ Here's the current tests, what they do, and why.
   - verifies "podman compose" works
   - verifies the alias to "docker" works
   - prints some debug info about versions and container networks to the console
+- `sudo-fails` (composite Action) - verifies sudo doesn't work
+- `sudo-works` (composite Action) - verifies sudo works

--- a/tests/container/Dockerfile
+++ b/tests/container/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3-slim
+COPY test.py /app/test.py
+WORKDIR /app
+ENV PYTHONPATH /app
+CMD ["/app/test.py"]

--- a/tests/container/action.yml
+++ b/tests/container/action.yml
@@ -1,0 +1,7 @@
+name: "Container Action test"
+
+description: "Test building and running a container Action"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/tests/container/test.py
+++ b/tests/container/test.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+print("It looks like container Actions work exactly as expected.")
+print("Have a nice day!")

--- a/tests/debug/action.yml
+++ b/tests/debug/action.yml
@@ -1,0 +1,20 @@
+name: "Dump debug info"
+
+description: "Dump debug output from the image at test time"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Environment variable dump"
+      shell: bash
+      run: |
+        printenv
+
+    - name: "Who am I?"
+      shell: bash
+      run: |
+        whoami
+        echo "UID: $(id -u)"
+        echo "GID: $(id -g)"
+        echo "GROUPS: $(id -G)"
+        echo "GROUPS: $(groups)"

--- a/tests/docker/action.yml
+++ b/tests/docker/action.yml
@@ -1,0 +1,26 @@
+name: "Docker tests"
+
+description: "Test the image for Docker related functionality"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Docker info"
+      shell: bash
+      run: |
+        docker info
+
+    - name: "Docker test"
+      shell: bash
+      run: |
+        docker run hello-world
+
+    - name: "Docker network info"
+      shell: bash
+      run: |
+        docker network inspect bridge
+
+    - name: "Docker compose test"
+      shell: bash
+      run: |
+        docker-compose --version

--- a/tests/podman/action.yml
+++ b/tests/podman/action.yml
@@ -1,0 +1,41 @@
+name: "Podman tests"
+
+description: "Test the image for Podman related functionality"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Podman info"
+      shell: bash
+      run: |
+        podman info
+
+    - name: "Podman test"
+      shell: bash
+      run: |
+        podman run hello-world
+
+    - name: "Docker alias test"
+      shell: bash
+      run: |
+        docker run hello-world
+
+    - name: "Podman network info"
+      shell: bash
+      run: |
+        podman network inspect podman
+
+    - name: "Podman compose test"
+      shell: bash
+      run: |
+        podman compose --version
+
+    - name: "Buildah info"
+      shell: bash
+      run: |
+        buildah info
+
+    - name: "Skopeo info"
+      shell: bash
+      run: |
+        skopeo -v

--- a/tests/sudo-fails/action.yml
+++ b/tests/sudo-fails/action.yml
@@ -1,0 +1,18 @@
+name: "Sudo fails"
+
+description: "Make sure `sudo` fails"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Sudo fails"
+      shell: bash
+      run: |
+        sudo echo "sudo works"
+        if $? -eq 0; then
+          echo "sudo works"
+          exit 1
+        else
+          echo "sudo fails"
+          exit 0
+        fi

--- a/tests/sudo-fails/action.yml
+++ b/tests/sudo-fails/action.yml
@@ -8,11 +8,10 @@ runs:
     - name: "Sudo fails"
       shell: bash
       run: |
-        sudo echo "sudo works"
-        if $? -eq 0; then
-          echo "sudo works"
+        if [ $(sudo echo "test") -eq 0 ]; then
+          echo "sudo should fail, but didn't"
           exit 1
         else
-          echo "sudo fails"
+          echo "sudo failed as expected"
           exit 0
         fi

--- a/tests/sudo-works/action.yml
+++ b/tests/sudo-works/action.yml
@@ -1,0 +1,11 @@
+name: "Sudo works"
+
+description: "Make sure `sudo` works"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Sudo fails"
+      shell: bash
+      run: |
+        sudo echo "sudo works"


### PR DESCRIPTION
Refactor image tests to provide more code reusability.

Tests for use in the build/test jobs are now in ~/tests and are built using GitHub Actions, since that's the whole thing we're wanting to work. 😆 