### PR TITLE
Fix release job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -125,7 +125,8 @@ jobs:
     needs: [build-podman, build-ubuntu]
     strategy:
       matrix:
-        runner-image: [podman, ubuntu-focal, rootless-ubuntu-focal]
+        runner-image:
+          [podman, ubuntu-focal, rootless-ubuntu-focal, ubuntu-jammy]
 
     steps:
       - name: Checkout
@@ -135,7 +136,7 @@ jobs:
         run: |
           echo ${{ secrets.DEPLOY_ACCOUNT }} | base64 -d > /tmp/config
 
-      - name: Update deployment
+      - name: Update deployments
         run: |
           kubectl apply -f deployments/${{ matrix.runner-image }}.yml
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: anchore/scan-action@v3
         id: scan
         with:
-          image: "ghcr.io/some-natalie/kubernoodles/${{ matrix.runner-image }}:latest"
+          image: "ghcr.io/some-natalie/kubernoodles/${{ matrix.runner-image }}:${{ env.VERSION }}"
           fail-build: false
           acs-report-enable: true
 
@@ -63,7 +63,7 @@ jobs:
       - name: Generate SBOM for the Ubuntu-based runners
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/some-natalie/kubernoodles/${{ matrix.runner-image }}:latest
+          image: ghcr.io/some-natalie/kubernoodles/${{ matrix.runner-image }}:${{ env.VERSION }}
 
   build-podman:
     runs-on: ubuntu-latest # use the GitHub hosted runners
@@ -95,7 +95,7 @@ jobs:
         uses: anchore/scan-action@v3
         id: scan
         with:
-          image: "ghcr.io/some-natalie/kubernoodles/podman:latest"
+          image: "ghcr.io/some-natalie/kubernoodles/podman:${{ env.VERSION }}"
           fail-build: false
           acs-report-enable: true
 
@@ -107,7 +107,7 @@ jobs:
       - name: Generate SBOM for the Podman (Fedora 35) runner
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/some-natalie/kubernoodles/podman:latest
+          image: ghcr.io/some-natalie/kubernoodles/podman:${{ env.VERSION }}
 
       - name: Push image
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -138,6 +138,8 @@ jobs:
 
       - name: Update deployments
         run: |
+          kubectl delete -f deployments/${{ matrix.runner-image }}.yml
+          sleep 30
           kubectl apply -f deployments/${{ matrix.runner-image }}.yml
         env:
           KUBECONFIG: /tmp/config


### PR DESCRIPTION
This PR
- adds Jammy to the deployment step
- adds a step to delete the existing deployments, then wait a bit, to the end deployment step
- move from `tag:latest` to `tag:${{env.VERSION}}` for scanning and SBOM steps to ensure it's always targeting the correct build