### PR TITLE
102 move to test and latest tags for repo use

### DIFF
--- a/.github/workflows/test-podman.yml
+++ b/.github/workflows/test-podman.yml
@@ -31,7 +31,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ghcr.io/some-natalie/kubernoodles/podman
-          tags: latest
+          tags: test
           containerfiles: images/podman.Dockerfile
 
       - name: Push image

--- a/.github/workflows/test-rootless-ubuntu-focal.yml
+++ b/.github/workflows/test-rootless-ubuntu-focal.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Build and push image
         run: |
-          docker build -t ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:latest -f images/rootless-ubuntu-focal.Dockerfile .
-          docker push ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:latest
+          docker build -t ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:test -f images/rootless-ubuntu-focal.Dockerfile .
+          docker push ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:test
 
   deploy:
     name: Deploy test image to `test-runners` namespace

--- a/.github/workflows/test-ubuntu-focal.yml
+++ b/.github/workflows/test-ubuntu-focal.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           file: "images/ubuntu-focal.Dockerfile"
           push: true
-          tags: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:latest
+          tags: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:test
 
   deploy:
     name: Deploy test image to `test-runners` namespace

--- a/.github/workflows/test-ubuntu-jammy.yml
+++ b/.github/workflows/test-ubuntu-jammy.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           file: "images/ubuntu-jammy.Dockerfile"
           push: true
-          tags: ghcr.io/some-natalie/kubernoodles/ubuntu-jammy:latest
+          tags: ghcr.io/some-natalie/kubernoodles/ubuntu-jammy:test
 
   deploy:
     name: Deploy test image to `test-runners` namespace

--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
           cut-off: Two hours ago UTC
           timestamp-to-use: created_at
           account-type: personal
-          untagged-only: true
+          skip-tags: latest, v*
           token: ${{ secrets.GHCR_CLEANUP_TOKEN }}
 
   stale:

--- a/deployments/test-podman.yml
+++ b/deployments/test-podman.yml
@@ -12,7 +12,7 @@ spec:
         - name: DISABLE_RUNNER_UPDATE # Disables automatic runner updates
           value: "true"
       ephemeral: true
-      image: ghcr.io/some-natalie/kubernoodles/podman:latest
+      image: ghcr.io/some-natalie/kubernoodles/podman:test
       imagePullPolicy: Always
       imagePullSecrets:
         - name: ghcr

--- a/deployments/test-rootless-ubuntu-focal.yml
+++ b/deployments/test-rootless-ubuntu-focal.yml
@@ -12,7 +12,7 @@ spec:
         - name: DISABLE_RUNNER_UPDATE # Disables automatic runner updates
           value: "true"
       ephemeral: true
-      image: ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:latest
+      image: ghcr.io/some-natalie/kubernoodles/rootless-ubuntu-focal:test
       imagePullPolicy: Always
       imagePullSecrets:
         - name: ghcr

--- a/deployments/test-ubuntu-focal.yml
+++ b/deployments/test-ubuntu-focal.yml
@@ -12,7 +12,7 @@ spec:
         - name: DISABLE_RUNNER_UPDATE # Disables automatic runner updates
           value: "true"
       ephemeral: true
-      image: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:latest
+      image: ghcr.io/some-natalie/kubernoodles/ubuntu-focal:test
       imagePullPolicy: Always
       imagePullSecrets:
         - name: ghcr

--- a/deployments/test-ubuntu-jammy.yml
+++ b/deployments/test-ubuntu-jammy.yml
@@ -12,7 +12,7 @@ spec:
         - name: DISABLE_RUNNER_UPDATE # Disables automatic runner updates
           value: "true"
       ephemeral: true
-      image: ghcr.io/some-natalie/kubernoodles/ubuntu-jammy:latest
+      image: ghcr.io/some-natalie/kubernoodles/ubuntu-jammy:test
       imagePullPolicy: Always
       imagePullSecrets:
         - name: ghcr


### PR DESCRIPTION
This PR moves the build/test jobs into a dedicated tag called `test`, leaving `latest` for the latest "real" build.  It also changes the container retention policy to leave images tagged `latest` or `v*`, but not others.