### PR TITLE
fix scaling ref for rootless runner deployment

### DIFF
--- a/deployments/rootless-ubuntu-focal.yml
+++ b/deployments/rootless-ubuntu-focal.yml
@@ -47,7 +47,7 @@ metadata:
   namespace: runners
 spec:
   scaleTargetRef:
-    name: ubuntu-focal
+    name: rootless-ubuntu-focal
   minReplicas: 2
   maxReplicas: 6
   scaleDownDelaySecondsAfterScaleOut: 60


### PR DESCRIPTION
The rootless deployment is looking at the rootful deployment to scale.  This PR fixes that :)