### PR TITLE
Fix static cache

### DIFF
--- a/deployments/podman.yml
+++ b/deployments/podman.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/rootless-ubuntu-focal.yml
+++ b/deployments/rootless-ubuntu-focal.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/test-podman.yml
+++ b/deployments/test-podman.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/test-rootless-ubuntu-focal.yml
+++ b/deployments/test-rootless-ubuntu-focal.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/test-ubuntu-focal.yml
+++ b/deployments/test-ubuntu-focal.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/test-ubuntu-jammy.yml
+++ b/deployments/test-ubuntu-jammy.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/ubuntu-focal.yml
+++ b/deployments/ubuntu-focal.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/deployments/ubuntu-jammy.yml
+++ b/deployments/ubuntu-jammy.yml
@@ -19,7 +19,7 @@ spec:
       dockerdWithinRunnerContainer: true
       dockerMTU: 1450
       volumeMounts:
-        - mountPath: /opt/hostedtoolcache
+        - mountPath: /opt/statictoolcache
           name: runnertoolcache
           readOnly: true
       volumes:

--- a/images/podman.Dockerfile
+++ b/images/podman.Dockerfile
@@ -61,6 +61,9 @@ ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
     && chown podman:podman /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache
+RUN mkdir /opt/statictoolcache \
+    && chgrp runner /opt/statictoolcache \
+    && chmod g+rwx /opt/statictoolcache
 
 # Copy files into the image
 COPY images/logger.sh /usr/bin/logger.sh

--- a/images/podman.Dockerfile
+++ b/images/podman.Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir /opt/hostedtoolcache \
     && chown podman:podman /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache
 RUN mkdir /opt/statictoolcache \
-    && chgrp runner /opt/statictoolcache \
+    && chown podman:podman /opt/statictoolcache \
     && chmod g+rwx /opt/statictoolcache
 
 # Copy files into the image

--- a/images/rootless-startup.sh
+++ b/images/rootless-startup.sh
@@ -20,6 +20,9 @@ jq ".\"registry-mirrors\"[0] = \"${DOCKER_REGISTRY_MIRROR}\"" /home/runner/.conf
 fi
 SCRIPT
 
+logger.notice "Symlinking static cache assets"
+ln -s /opt/statictoolcache/* /opt/hostedtoolcache && ls -l /opt/hostedtoolcache
+
 logger.notice "Starting Docker (rootless)"
 /home/runner/bin/dockerd-rootless.sh --config-file /home/runner/.config/docker/daemon.json >> /dev/null 2>&1 &
 

--- a/images/rootless-ubuntu-focal.Dockerfile
+++ b/images/rootless-ubuntu-focal.Dockerfile
@@ -103,6 +103,9 @@ ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
     && chgrp runner /opt/hostedtoolcache \
     && chmod g+rwx /opt/hostedtoolcache
+RUN mkdir /opt/statictoolcache \
+    && chgrp runner /opt/statictoolcache \
+    && chmod g+rwx /opt/statictoolcache
 
 # Configure hooks folder structure
 COPY images/hooks /etc/arc/hooks/

--- a/images/startup.sh
+++ b/images/startup.sh
@@ -39,6 +39,9 @@ sudo /usr/bin/supervisord -n >> /dev/null 2>&1 &
 logger.debug "Waiting for processes to be running"
 processes=(dockerd)
 
+logger.notice "Symlinking static cache assets"
+ln -s /opt/statictoolcache/* /opt/hostedtoolcache && ls -l /opt/hostedtoolcache
+
 for process in "${processes[@]}"; do
     sleep 10
     wait_for_process "$process"

--- a/images/ubuntu-focal.Dockerfile
+++ b/images/ubuntu-focal.Dockerfile
@@ -123,6 +123,9 @@ ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
   && chgrp runner /opt/hostedtoolcache \
   && chmod g+rwx /opt/hostedtoolcache
+RUN mkdir /opt/statictoolcache \
+  && chgrp runner /opt/statictoolcache \
+  && chmod g+rwx /opt/statictoolcache
 
 # Install dumb-init, arch command on OS X reports "i386" for Intel CPUs regardless of bitness
 RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/images/ubuntu-jammy.Dockerfile
+++ b/images/ubuntu-jammy.Dockerfile
@@ -121,6 +121,9 @@ ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 RUN mkdir /opt/hostedtoolcache \
   && chgrp runner /opt/hostedtoolcache \
   && chmod g+rwx /opt/hostedtoolcache
+RUN mkdir /opt/statictoolcache \
+  && chgrp runner /opt/statictoolcache \
+  && chmod g+rwx /opt/statictoolcache
 
 # Install dumb-init, arch command on OS X reports "i386" for Intel CPUs regardless of bitness
 RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \

--- a/tests/cache/action.yml
+++ b/tests/cache/action.yml
@@ -5,10 +5,10 @@ description: "Verify that the PersistentVolumeClaim tool cache is mounted and wo
 runs:
   using: "composite"
   steps:
-    - name: "Verify tool cache is mounted and not empty"
+    - name: "Verify static tool cache is mounted and not empty"
       shell: bash
       run: |
-        [ "$(ls -A /opt/hostedtoolcache)" ] && echo "Mounted" || (echo "Empty mount" && exit 2)
+        [ "$(ls -A /opt/statictoolcache)" ] && echo "Mounted" || (echo "Empty mount" && exit 2)
 
     - name: "List contents of tool cache"
       shell: bash


### PR DESCRIPTION
This pull request adds another directory (`/opt/statictoolcache`) to mount the static hosted assets, like Python versions, that are then symlinked into `/opt/hostedtoolcache` for the runners to use.