### PR TITLE
only scan on one architecture to dedupe results

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -57,12 +57,14 @@ jobs:
       - name: Scan it
         uses: anchore/scan-action@v4
         id: scan
+        if: matrix.arch == 'amd64'
         with:
           image: "ghcr.io/${{ github.repository }}/${{ matrix.os }}:${{ env.SHA_SHORT }}"
           fail-build: false
 
       - name: Upload the container scan report
         uses: github/codeql-action/upload-sarif@v3
+        if: matrix.arch == 'amd64'
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 


### PR DESCRIPTION
# Pull request

Only scan one architecture to deduplicate findings in the security tab.  Not perfect, as it's possible some CVEs will only exist on one or the other, but 🤷🏻‍♀️ there's plenty of alerts to go around and you'll probably be using your own scanner anyways.

## Describe your changes

This pull request includes a small change to the `.github/workflows/build-latest.yml` file. The change adds a condition to ensure that certain steps are only executed for the `amd64` architecture.

* [`.github/workflows/build-latest.yml`](diffhunk://#diff-b27178cc538468c70998f0ef6cc46dc7c330f852141bec96b069481d986d5fa2R60-R67): Added `if: matrix.arch == 'amd64'` condition to the `Scan it` and `Upload the container scan report` steps.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests and documentation
