### PR TITLE
move everything to squash builds to save space

### DIFF
--- a/images/rootless-ubuntu-jammy.Dockerfile
+++ b/images/rootless-ubuntu-jammy.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS build
 
 # GitHub runner arguments
 ARG RUNNER_VERSION=2.321.0
@@ -14,15 +14,6 @@ ARG DUMB_INIT_VERSION=1.2.5
 # Other arguments, expose TARGETPLATFORM for multi-arch builds
 ARG DEBUG=false
 ARG TARGETPLATFORM
-
-# Label all the things!!
-LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
-LABEL org.opencontainers.image.path="images/rootless-ubuntu-jammy.Dockerfile"
-LABEL org.opencontainers.image.title="rootless-ubuntu-jammy"
-LABEL org.opencontainers.image.description="An Ubuntu Jammy (22.04 LTS) based runner image for GitHub Actions, rootless"
-LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
-LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
 
 # Set environment variables needed at build or run
 ENV DEBIAN_FRONTEND=noninteractive
@@ -126,6 +117,31 @@ RUN mkdir -p /run/user/1000 \
   && chown runner:runner /home/runner/externals \
   && chmod a+x /home/runner/externals
 
+# Docker-compose installation
+RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
+  && export ARCH \
+  && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
+  && if [ "$ARCH" = "amd64" ]; then export ARCH=x86_64 ; fi \
+  && curl --create-dirs -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-${ARCH}" -o /home/runner/bin/docker-compose ; \
+  chmod +x /home/runner/bin/docker-compose
+
+# squash it!
+FROM scratch AS final
+
+# Label all the things!!
+LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
+LABEL org.opencontainers.image.path="images/rootless-ubuntu-jammy.Dockerfile"
+LABEL org.opencontainers.image.title="rootless-ubuntu-jammy"
+LABEL org.opencontainers.image.description="An Ubuntu Jammy (22.04 LTS) based runner image for GitHub Actions, rootless"
+LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+
+# Set environment variables needed at build or run
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUNNER_MANUALLY_TRAP_SIG=1
+ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
+
 # Add the Python "User Script Directory" to the PATH
 ENV HOME=/home/runner
 ENV PATH="${PATH}:${HOME}/.local/bin:/home/runner/bin"
@@ -134,12 +150,6 @@ ENV ImageOS=ubuntu22
 # No group definition, as that makes it harder to run docker.
 USER runner
 
-# Docker-compose installation
-RUN ARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
-  && export ARCH \
-  && if [ "$ARCH" = "arm64" ]; then export ARCH=aarch64 ; fi \
-  && if [ "$ARCH" = "amd64" ]; then export ARCH=x86_64 ; fi \
-  && curl --create-dirs -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-${ARCH}" -o /home/runner/bin/docker-compose ; \
-  chmod +x /home/runner/bin/docker-compose
+COPY --from=build / /
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/images/ubi8.Dockerfile
+++ b/images/ubi8.Dockerfile
@@ -1,12 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
-
-LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
-LABEL org.opencontainers.image.path="images/ubi8.Dockerfile"
-LABEL org.opencontainers.image.title="ubi8"
-LABEL org.opencontainers.image.description="A RedHat UBI 8 based runner image for GitHub Actions"
-LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
-LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10 AS build
 
 # Arguments
 ARG TARGETPLATFORM
@@ -78,4 +70,22 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
   && unzip ./runner-container-hooks.zip -d ./k8s \
   && rm runner-container-hooks.zip
 
+# Squash it!
+FROM scratch AS final
+
+LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
+LABEL org.opencontainers.image.path="images/ubi8.Dockerfile"
+LABEL org.opencontainers.image.title="ubi8"
+LABEL org.opencontainers.image.description="A RedHat UBI 8 based runner image for GitHub Actions"
+LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+
+# The UID env var should be used in child Containerfile.
+ENV UID=1000
+ENV GID=0
+ENV USERNAME="runner"
+
 USER $USERNAME
+
+COPY --from=build / /

--- a/images/ubi9.Dockerfile
+++ b/images/ubi9.Dockerfile
@@ -1,12 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-init:9.5
-
-LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
-LABEL org.opencontainers.image.path="images/ubi9.Dockerfile"
-LABEL org.opencontainers.image.title="ubi9"
-LABEL org.opencontainers.image.description="A RedHat UBI 9 based runner image for GitHub Actions"
-LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
-LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+FROM registry.access.redhat.com/ubi9/ubi-init:9.5 AS build
 
 # Arguments
 ARG TARGETPLATFORM
@@ -78,4 +70,22 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
   && unzip ./runner-container-hooks.zip -d ./k8s \
   && rm runner-container-hooks.zip
 
+# Squash it!
+FROM scratch AS final
+
+LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
+LABEL org.opencontainers.image.path="images/ubi9.Dockerfile"
+LABEL org.opencontainers.image.title="ubi9"
+LABEL org.opencontainers.image.description="A RedHat UBI 9 based runner image for GitHub Actions"
+LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+
+# The UID env var should be used in child Containerfile.
+ENV UID=1000
+ENV GID=0
+ENV USERNAME="runner"
+
 USER $USERNAME
+
+COPY --from=build / /

--- a/images/wolfi.Dockerfile
+++ b/images/wolfi.Dockerfile
@@ -1,12 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest
-
-LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
-LABEL org.opencontainers.image.path="images/wolfi.Dockerfile"
-LABEL org.opencontainers.image.title="wolfi"
-LABEL org.opencontainers.image.description="A Chainguard Wolfi based runner image for GitHub Actions"
-LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
-LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+FROM cgr.dev/chainguard/wolfi-base:latest AS build
 
 # Arguments
 ARG TARGETPLATFORM
@@ -69,10 +61,23 @@ RUN curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-c
   && unzip ./runner-container-hooks.zip -d ./k8s \
   && rm runner-container-hooks.zip
 
-ENV RUNNER_MANUALLY_TRAP_SIG=1
-ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
-
 # configure directory permissions; ref https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/configure-system.sh
 RUN chmod -R 777 /opt /usr/share
 
+# squash it!
+FROM scratch AS final
+
+LABEL org.opencontainers.image.source="https://github.com/some-natalie/kubernoodles"
+LABEL org.opencontainers.image.path="images/wolfi.Dockerfile"
+LABEL org.opencontainers.image.title="wolfi"
+LABEL org.opencontainers.image.description="A Chainguard Wolfi based runner image for GitHub Actions"
+LABEL org.opencontainers.image.authors="Natalie Somersall (@some-natalie)"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.documentation="https://github.com/some-natalie/kubernoodles/README.md"
+
+ENV RUNNER_MANUALLY_TRAP_SIG=1
+ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
+
 USER runner
+
+COPY --from=build / /


### PR DESCRIPTION
# Pull request

## Describe your changes

move everything to a multi-stage build and then a single layer squashed image at the end, saving about 200 MB per image

## Issue ticket number and link

closes #101 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests and documentation
