### PR TITLE
add header

### DIFF
--- a/.github/workflows/janky-dependabot.yml
+++ b/.github/workflows/janky-dependabot.yml
@@ -105,6 +105,7 @@ jobs:
           RESPONSE=$(curl -X POST \
             -H "Authorization: bearer ${{ secrets.COPILOT_USER }}" \
             -H "Content-Type: application/json" \
+            -H "GraphQL-Features: issues_copilot_assignment_api_support" \
             --data-raw "$JSON_PAYLOAD" \
             https://api.github.com/graphql)
 


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/janky-dependabot.yml` workflow. The change adds a new header to the GraphQL API request to enable support for the Copilot assignment API.

* Added the `GraphQL-Features: issues_copilot_assignment_api_support` header to the GraphQL request in `.github/workflows/janky-dependabot.yml` to enable Copilot assignment API features.