### PR TITLE
Stop deleting untagged multi-arch manifest children

### DIFF
--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -6,32 +6,11 @@ on:
     - cron: "30 22 * * 1" # Weekly at 22:30 UTC on Mondays
 
 jobs:
-  clean-ghcr:
-    name: Delete old unused container images
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-          - ubuntu-focal
-          - rootless-ubuntu-focal
-          - ubuntu-jammy
-          - rootless-ubuntu-jammy
-          - rootless-ubuntu-numbat
-          - rootless-ubuntu-resolute
-          - podman
-          - ubi8
-          - ubi9
-          - ubi10
-          - wolfi
-    steps:
-      - name: Delete untagged container images older than 2 months
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: kubernoodles/${{ matrix.runner }}
-          package-type: "container"
-          min-versions-to-keep: 8
-          delete-only-untagged-versions: "true"
+  # The ghcr cleanup job is gone on purpose.  Our images are multi-arch, so the
+  # `latest` tag belongs to an OCI index whose per-arch child manifests are
+  # untagged by design.  `delete-only-untagged-versions` reaped those children
+  # and left `latest` pointing at manifests that no longer existed, breaking
+  # `docker pull` with `manifest unknown` every Monday.
 
   stale:
     name: Destalinate!


### PR DESCRIPTION
## Summary

- Remove the `clean-ghcr` job from `weekly-cleanup.yml`.

The job ran `actions/delete-package-versions` with `delete-only-untagged-versions: true`. Our images are multi-arch, so the `latest` tag belongs to an OCI index whose per-arch child manifests carry no tags of their own. The cleanup treated those children as orphans and deleted them. The index kept its tag and pointed at manifests that no longer existed.

Result: `docker pull ghcr.io/some-natalie/kubernoodles/<image>:latest` fails with `manifest unknown` on both amd64 and arm64, for every image in the matrix, after each Monday run.

Confirmed against the registry — `wolfi:latest` resolves to an index referencing `sha256:cbef4b64…` (amd64) and `sha256:4b4a58ee…` (arm64), both of which 404 by digest via curl, skopeo, and docker. The single-arch short-SHA tags (`wolfi:029ef0a`) still pull fine, since they have their own tags.

`min-versions-to-keep: 8` did not prevent this; more than 8 untagged children accumulate across builds.

## Test plan

- [ ] Re-run `🍜 Build/publish all runners` to republish the `latest` indexes and their children
- [ ] `docker pull ghcr.io/some-natalie/kubernoodles/wolfi:latest --platform linux/arm64`
- [ ] `docker pull ghcr.io/some-natalie/kubernoodles/wolfi:latest --platform linux/amd64`
- [ ] Spot-check one other image, e.g. `ubi9:latest`
- [ ] Confirm `latest` still pulls after the next scheduled Monday cleanup

Untagged manifests will now accumulate in ghcr. If that becomes a problem, the replacement needs to walk each tagged index and exclude the child digests it references before deleting anything — `delete-package-versions` cannot do that today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)